### PR TITLE
NP-2423 Restart telegraf service when the config is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 
 # 0.1.1
 - Add source URL to metadata
+
+# 0.1.2
+- Add support for restarting the service when config changes
+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ as needed.  Alternatively, you can use the custom resources directly.
 
 #### telegraf_install
 
-Installs telegraf
+Installs telegraf and configures the service
 
 ```ruby
 telegraf_install 'default' do

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'apache2'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.1.1'
+version '0.1.2'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 
 depends 'yum'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,3 @@ telegraf_config 'default' do
   outputs node['telegraf']['outputs']
   plugins node['telegraf']['plugins']
 end
-
-service 'telegraf' do
-  action [:enable, :start]
-end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -52,9 +52,20 @@ action :create do
   else
     raise "#{install_type} is not a valid install type."
   end
+
+  service "telegraf_#{name}" do
+    service_name 'telegraf'
+    action [:enable, :start]
+  end
 end
 
 action :delete do
-  package 'telegraf'
-  action :delete
+  service "telegraf_#{name}" do
+    service_name 'telegraf'
+    action [:stop, :disable]
+  end
+
+  package 'telegraf' do
+    action :remove
+  end
 end

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -20,6 +20,7 @@
 property :name, String, name_property: true
 property :outputs, Hash, required: true
 property :path, String, required: true
+property :reload, kind_of: [TrueClass, FalseClass], default: true
 
 default_action :create
 
@@ -35,7 +36,13 @@ action :create do
 
   require 'toml'
 
+  service "telegraf_#{new_resource.name}" do
+    service_name 'telegraf'
+    action :nothing
+  end
+
   file "#{path}/#{name}_outputs.conf" do
     content TOML.dump(outputs)
+    notifies :restart, "service[telegraf_#{new_resource.name}]", :delayed if reload
   end
 end

--- a/resources/plugins.rb
+++ b/resources/plugins.rb
@@ -20,6 +20,7 @@
 property :name, String, name_property: true
 property :plugins, Hash, required: true
 property :path, String, required: true
+property :reload, kind_of: [TrueClass, FalseClass], default: true
 
 default_action :create
 
@@ -35,7 +36,13 @@ action :create do
 
   require 'toml'
 
+  service "telegraf_#{new_resource.name}" do
+    service_name 'telegraf'
+    action :nothing
+  end
+
   file "#{path}/#{name}_plugins.conf" do
     content TOML.dump(plugins)
+    notifies :restart, "service[telegraf_#{new_resource.name}]", :delayed if reload
   end
 end


### PR DESCRIPTION
Quick change to restart telegraf, although it's not done from the actual resource. Adding use_inline_resources will make sure the result of the resource is bubbled up (updated_by_last_action is deprecated according to docs).

May be better to create a new resource telegraf_instance which does everything (install, config, service) and get rid of the others. That way we can safely restart the service from within the resource when the config changes. I don't think you'd ever want to install without config or vice versa. 
