### PR TITLE
NP-2485: Add install_version property to enforce specific telegraf version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+LineLength:
+  Max: 100
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,6 @@
 # 0.1.3
 - Add support for multiple outputs/plugins config files
 
+# 0.1.4
+- Add install_version property to install resource to enforce specific telegraf version
+

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ as needed.  Alternatively, you can use the custom resources directly.
 
 #### telegraf_install
 
-Installs telegraf and configures the service
+Installs telegraf and configures the service. Optionally specifies a version, otherwise the latest available is installed
 
 ```ruby
 telegraf_install 'default' do
+  install_version '0.2.4'
   action :create
 end
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,8 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# By default, always installs the latest by specifying nil
-default['telegraf']['version'] = nil
 default['telegraf']['config_file_path'] = '/etc/opt/telegraf/telegraf.conf'
 default['telegraf']['config'] = {
   'tags' => {},

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'apache2'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.1.3'
+version '0.1.4'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 
 depends 'yum'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 telegraf_install 'default' do
+  install_version '0.2.4'
   action :create
 end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -19,7 +19,6 @@
 require 'spec_helper'
 
 describe 'telegraf::default' do
-
   platforms = {
     'centos' => ['6.6', '7.0'],
     'ubuntu' => ['14.04']
@@ -27,10 +26,9 @@ describe 'telegraf::default' do
 
   platforms.each do |platform, versions|
     versions.each do |version|
-
       context "on #{platform.capitalize} #{version}" do
-        let (:chef_run) do
-          ChefSpec::SoloRunner.new(log_level: :error, platform: platform, version: version) do |node|
+        let(:chef_run) do
+          ChefSpec::SoloRunner.new(log_level: :error, platform: platform, version: version) do
           end.converge(described_recipe)
         end
 

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -7,21 +7,19 @@ describe package(package_name) do
   it { should be_installed }
 end
 
-%w{ /etc/opt/telegraf /etc/opt/telegraf/telegraf.d }.each do |d|
+%w( /etc/opt/telegraf /etc/opt/telegraf/telegraf.d ).each do |d|
   describe file(d) do
     it { should be_directory }
   end
 end
 
-%w{ telegraf.conf telegraf.d/default_outputs.conf telegraf.d/default_plugins.conf }.each do |c|
+%w( telegraf.conf telegraf.d/default_outputs.conf telegraf.d/default_plugins.conf ).each do |c|
   describe file("#{conf_dir}/#{c}") do
     it { should be_file }
   end
 end
 
-
 describe service('telegraf') do
   it { should be_enabled }
   it { should be_running }
 end
-

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -11,7 +11,7 @@ end
 RSpec.configure do |c|
   if ENV['ASK_SUDO_PASSWORD']
     require 'highline/import'
-    c.sudo_password = ask("Enter sudo password: ") { |q| q.echo = false }
+    c.sudo_password = ask('Enter sudo password: ') { |q| q.echo = false }
   else
     c.sudo_password = ENV['SUDO_PASSWORD']
   end


### PR DESCRIPTION
Currently the telegraf cookbook installs the latest available version. v0.10 was just released which has a different configuration format, and, if installed, won't work properly with the cookbook. 
This PR adds an install_version property to the install resource (and gets rid of the version attribute) and pins the version in the default recipe until we rewrite the cookbook to support v0.10.
Also fixes a bunch of rubocop warnings.
