### PR TITLE
Sane defaults for plugins/ouputs paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,5 @@
 # 0.1.4
 - Add install_version property to install resource to enforce specific telegraf version
 
+# 0.1.5
+- Add sane defaults for plugins/outputs path

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'apache2'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.1.4'
+version '0.1.5'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 
 depends 'yum'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -21,7 +21,7 @@ property :name, String, name_property: true
 property :config, Hash, default: {}
 property :outputs, Hash, default: {}
 property :plugins, Hash, default: {}
-property :path, String
+property :path, String, default: node['telegraf']['config_file_path']
 
 default_action :create
 

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -19,7 +19,8 @@
 
 property :name, String, name_property: true
 property :outputs, Hash, required: true
-property :path, String, required: true
+property :path, String,
+         default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'
 property :reload, kind_of: [TrueClass, FalseClass], default: true
 

--- a/resources/plugins.rb
+++ b/resources/plugins.rb
@@ -19,7 +19,8 @@
 
 property :name, String, name_property: true
 property :plugins, Hash, required: true
-property :path, String, required: true
+property :path, String,
+         default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'
 property :reload, kind_of: [TrueClass, FalseClass], default: true
 


### PR DESCRIPTION
Add sane defaults for path attribute on config, plugins and outputs (so by default, you don't need to know or care where it goes)
