### PR TITLE
NP-2498 Dont expect top level names for plugins and outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,6 @@
 
 # 0.1.5
 - Add sane defaults for plugins/outputs path
+
+# 0.2.0
+- Change format for output/plugins to not require a top level name

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ as needed.  Alternatively, you can use the custom resources directly.
 | node['telegraf']['version']          | String | Version of telegraf to install, nil = latest          | nil                                                                                                                                                                 |
 | node['telegraf']['config_file_path'] | String | Location of the telgraf main config file              | '/etc/opt/telegraf/telegraf.conf'                                                                                                                                   |
 | node['telegraf']['config']           | Hash   | Config variables to be written to the telegraf config | {'tags' => {},'agent' => {'interval' => '10s','round_interval' => true,'flush_interval' => '10s','flush_jitter' => '5s'}                                            |
-| node['telegraf']['outputs']          | Hash   | telegraf outputs                                      | {'outputs' => ['influxdb' => {'urls' => ['http://localhost:8086'],'database' => 'telegraf','precision' => 's'}]}                                                    |
-| node['telegraf']['plugins']          | Hash   | telegraf plugins                                      | {'plugins' => {'cpu' => {'percpu' => true,'totalcpu' => true,'drop' => ['cpu_time'],},'disk' => {},'io' => {},'mem' => {},'net' => {},'swap' => {},'system' => {}}} |
+| node['telegraf']['outputs']          | Array  | telegraf outputs                                      | ['influxdb' => {'urls' => ['http://localhost:8086'],'database' => 'telegraf','precision' => 's'}]                                                                   |
+| node['telegraf']['plugins']          | Hash   | telegraf plugins                                      | {'cpu' => {'percpu' => true,'totalcpu' => true,'drop' => ['cpu_time'],},'disk' => {},'io' => {},'mem' => {},'net' => {},'swap' => {},'system' => {}}                |
 
 ### Custom Resources
 
@@ -85,10 +85,8 @@ For example, to add the nginx plugin:
 
 ```ruby
 node.default['telegraf']['nginx'] = {
-  'plugins' => {
-    'nginx' => {
-      'urls' => ['http://localhost/status']
-    }
+  'nginx' => {
+    'urls' => ['http://localhost/status']
   }
 }
 
@@ -107,7 +105,7 @@ Note that there are two optional parameters for this resource that could've been
 ## License and Authors
 
 ```text
-Copyright (C) 2015 NorthPage
+Copyright (C) 2015-2016 NorthPage
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: telegraf
 # Attributes:: default
 #
-# Copyright 2015 NorthPage
+# Copyright 2015-2016 NorthPage
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,27 +27,24 @@ default['telegraf']['config'] = {
     'flush_jitter' => '5s'
   }
 }
-default['telegraf']['outputs'] = {
-  'outputs' => [
-    'influxdb' => {
-      'urls' => ['http://localhost:8086'],
-      'database' => 'telegraf',
-      'precision' => 's'
-    }
-  ]
-}
-default['telegraf']['plugins'] = {
-  'plugins' => {
-    'cpu' => {
-      'percpu' => true,
-      'totalcpu' => true,
-      'drop' => ['cpu_time']
-    },
-    'disk' => {},
-    'io' => {},
-    'mem' => {},
-    'net' => {},
-    'swap' => {},
-    'system' => {}
+default['telegraf']['outputs'] = [
+  'influxdb' => {
+    'urls' => ['http://localhost:8086'],
+    'database' => 'telegraf',
+    'precision' => 's'
   }
+]
+
+default['telegraf']['plugins'] = {
+  'cpu' => {
+    'percpu' => true,
+    'totalcpu' => true,
+    'drop' => ['cpu_time']
+  },
+  'disk' => {},
+  'io' => {},
+  'mem' => {},
+  'net' => {},
+  'swap' => {},
+  'system' => {}
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'apache2'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.1.5'
+version '0.2.0'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 
 depends 'yum'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: telegraf
 # Recipe:: default
 #
-# Copyright 2015 NorthPage
+# Copyright 2015-2016 NorthPage
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: telegraf
 # Resource:: config
 #
-# Copyright 2015 NorthPage
+# Copyright 2015-2016 NorthPage
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 property :name, String, name_property: true
 property :config, Hash, default: {}
-property :outputs, Hash, default: {}
+property :outputs, Array, default: {}
 property :plugins, Hash, default: {}
 property :path, String, default: node['telegraf']['config_file_path']
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: telegraf
 # Resource:: install
 #
-# Copyright 2015 NorthPage
+# Copyright 2015-2016 NorthPage
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: telegraf
 # Resource:: outputs
 #
-# Copyright 2015 NorthPage
+# Copyright 2015-2016 NorthPage
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 property :name, String, name_property: true
-property :outputs, Hash, required: true
+property :outputs, Array, required: true
 property :path, String,
          default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'
@@ -44,7 +44,7 @@ action :create do
   end
 
   file "#{path}/#{name}_outputs.conf" do
-    content TOML.dump(outputs)
+    content TOML.dump('outputs' => outputs)
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
   end
 end

--- a/resources/plugins.rb
+++ b/resources/plugins.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: telegraf
 # Resource:: plugins
 #
-# Copyright 2015 NorthPage
+# Copyright 2015-2016 NorthPage
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ action :create do
   end
 
   file "#{path}/#{name}_plugins.conf" do
-    content TOML.dump(plugins)
+    content TOML.dump('plugins' => plugins)
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: telegraf
 # Spec:: default
 #
-# Copyright 2015 NorthPage
+# Copyright 2015-2016 NorthPage
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is to fix https://github.com/NorthPage/telegraf-cookbook/pull/9
