### PR TITLE
Allow specifying whether or not to bring in external repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ as needed.  Alternatively, you can use the custom resources directly.
 | node['telegraf']['config']           | Hash   | Config variables to be written to the telegraf config | {'tags' => {},'agent' => {'interval' => '10s','round_interval' => true,'flush_interval' => '10s','flush_jitter' => '5s'}                                            |
 | node['telegraf']['outputs']          | Array  | telegraf outputs                                      | ['influxdb' => {'urls' => ['http://localhost:8086'],'database' => 'telegraf','precision' => 's'}]                                                                   |
 | node['telegraf']['plugins']          | Hash   | telegraf plugins                                      | {'cpu' => {'percpu' => true,'totalcpu' => true,'drop' => ['cpu_time'],},'disk' => {},'io' => {},'mem' => {},'net' => {},'swap' => {},'system' => {}}                |
+| node['telegraf']['include_repository'] | [TrueClass, FalseClass] | Whether or not to pull in the InfluxDB repository to install from. | true |
 
 ### Custom Resources
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,9 @@ default['telegraf']['config'] = {
     'flush_jitter' => '5s'
   }
 }
+
+default['telegraf']['include_repository'] = true
+
 default['telegraf']['outputs'] = [
   'influxdb' => {
     'urls' => ['http://localhost:8086'],

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 telegraf_install 'default' do
+  include_repository node['telegraf']['include_repository']
   install_version '0.2.4'
   action :create
 end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+property :include_repository, [TrueClass, FalseClass], default: true
 property :name, String, name_property: true
 property :install_version, String, default: nil
 property :install_type, String, default: 'package'
@@ -31,13 +32,16 @@ action :create do
         description 'InfluxDB Repository - RHEL \$releasever'
         baseurl 'https://repos.influxdata.com/centos/\$releasever/\$basearch/stable'
         gpgkey 'https://repos.influxdata.com/influxdb.key'
+        only_if { include_repository }
       end
 
       # append release to rpm package version until yum_package is fixed:
       # https://github.com/chef/chef/issues/4103
       install_version << '-1' unless install_version.nil?
     else
-      package 'apt-transport-https'
+      package 'apt-transport-https' do
+        only_if { include_repository }
+      end
 
       apt_repository 'influxdb' do
         uri "https://repos.influxdata.com/#{node['platform']}"
@@ -45,6 +49,7 @@ action :create do
         components ['stable']
         arch 'amd64'
         key 'https://repos.influxdata.com/influxdb.key'
+        only_if { include_repository }
       end
     end
 


### PR DESCRIPTION
For users who maintain internal repositories or caches, it should be possible to have the telegraf cookbook not bring in the InfluxDB repository, and instead manage package sources outside the scope of the cookbook.
