### PR TITLE
outthentic integration tests for telegraf

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,4 +24,11 @@ suites:
   - name: default
     run_list:
       - recipe[telegraf::default]
+      - recipe[sparrow]
     attributes:
+    sparrow:
+      plugin:
+        list: [
+          'outth-telegraf'
+        ]
+

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,9 +26,9 @@ suites:
       - recipe[telegraf::default]
       - recipe[sparrow]
     attributes:
-    sparrow:
-      plugin:
-        list: [
-          'outth-telegraf'
-        ]
+     sparrow:
+       plugin:
+         list: [
+           'outth-telegraf'
+         ]
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
 source 'https://supermarket.chef.io'
 
 metadata
+cookbook 'sparrow'

--- a/test/integration/default/bash/outth_test.bash
+++ b/test/integration/default/bash/outth_test.bash
@@ -1,0 +1,9 @@
+# here we go!
+PATH=$PATH:/usr/local/bin/
+sparrow 1>/dev/null || exit 1
+sparrow project create foo
+sparrow check add foo tele
+sparrow check set foo tele outth-telegraf
+sparrow check show foo tele 
+match_l=1000 sparrow check run foo tele
+

--- a/test/integration/default/bash/outth_test.bash
+++ b/test/integration/default/bash/outth_test.bash
@@ -1,5 +1,5 @@
 # here we go!
-PATH=$PATH:/usr/local/bin/
+PATH=$PATH:/usr/local/bin/:/opt/telegraf
 sparrow 1>/dev/null || exit 1
 sparrow project create foo
 sparrow check add foo tele


### PR DESCRIPTION
Hi!

This is [outthentic integration tests](https://sparrowhub.org/info/outth-telegraf?v=0.000003) for telegraf service. A simple checks for output from telegraf client 

At my kitchen environment it looks like this

```
C:\Users\melezal1\projects\telegraf-cookbook>kitchen verify centos-66
-----> Starting Kitchen (v1.4.2)
C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient/webagent-cookie.rb:458: warning: already initialized constant HTTPClient::CookieManager
C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient/cookie.rb:8: warning: previous definition of CookieManager was here
-----> Verifying <default-centos-66>...
       Preparing files for transfer
-----> Busser installation detected (busser)
       Installing Busser plugins: busser-bash busser-serverspec
       Plugin bash already installed
       Plugin serverspec already installed
       Removing /tmp/verifier/suites/serverspec
       Removing /tmp/verifier/suites/bash
       Transferring files to <default-centos-66>
-----> Running bash test suite
-----> [bash] outth_test.bash
       project foo already exists - nothing to do here ...

       checkpoint foo/tele already exists at /usr/local/share/perl5/Sparrow/Commands/CheckPoint.pm line 42
        Sparrow::Commands::CheckPoint::check_add('foo', 'tele') called at /usr/local/bin/sparrow line 123
       checkpoint - set plugin to public@outth-telegraf

       [checkpoint foo/tele]

       {
          'install_dir' => 'public/outth-telegraf',
          'plugin' => 'public@outth-telegraf',
          'type' => 'public'
        }


       test suite ini file: not found
       # running cd /root/sparrow/plugins/public/outth-telegraf && carton exec 'strun --root ./  ' ...

       /tmp/.outthentic/14302/root/sparrow/plugins/public/outth-telegraf/cpu-metric/story.t ...
       ok 1 - perl /root/sparrow/plugins/public/outth-telegraf/modules/make-config/story.pl succeeded
       ok 2 - stdout saved to /tmp/.outthentic/14302/DyulbduYmd
       ok 3 - output match 'OK'
       ok 4 - perl /root/sparrow/plugins/public/outth-telegraf/cpu-metric/story.pl succeeded
       ok 5 - stdout saved to /tmp/.outthentic/14302/lJn4GkmOBF
       ok 6 - output match 'cpu'
       ok 7 - output match /Plugin:\s+cpu,\s+Collection/
       1..7
       ok
       /tmp/.outthentic/14302/root/sparrow/plugins/public/outth-telegraf/usage-mysql/story.t ..
       ok 1 - perl /root/sparrow/plugins/public/outth-telegraf/usage-mysql/story.pl succeeded
       ok 2 - stdout saved to /tmp/.outthentic/14302/fGX9qN9Q_P
       ok 3 - output match 'Read metrics from one or many mysql servers'
       1..3
       ok
       /tmp/.outthentic/14302/root/sparrow/plugins/public/outth-telegraf/version/story.t ......
       ok 1 - perl /root/sparrow/plugins/public/outth-telegraf/version/story.pl succeeded
       ok 2 - stdout saved to /tmp/.outthentic/14302/65ENtTENqj
       ok 3 - output match /Telegraf - Version \S+/
       ok 4 - 'Telegraf - Version 0.2.4' match /Version (\S+)/
       1..4
       ok
       All tests successful.
       Files=3, Tests=14,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.21 cusr  0.05 csys =  0.29 CPU)
       Result: PASS
```
