### PR TITLE
Fix installation on Amazon Linux and add support for Ubuntu 15.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
+  - name: ubuntu-15.04
   - name: centos-6.6
   - name: centos-7.1
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ cookbook.  ie. `[netstat]` requires `lsof`
 
 ## Tested Platforms
 
-* CentOS 7.1
-* Ubuntu 14.04
+* CentOS 6.6 and 7.1
+* Ubuntu 14.04 and 15.04
+* Amazon Linux 
 
 ## Requirements
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 # version of telegraf to install, e.g. '0.10.0-1' or nil for the latest
-default['telegraf']['version'] = '0.10.2-1'
+default['telegraf']['version'] = '0.10.3-1'
 default['telegraf']['config_file_path'] = '/etc/telegraf/telegraf.conf'
 default['telegraf']['config'] = {
   'tags' => {},

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -30,7 +30,14 @@ action :create do
     if platform_family? 'rhel'
       yum_repository 'telegraf' do
         description 'InfluxDB Repository - RHEL \$releasever'
-        baseurl 'https://repos.influxdata.com/centos/\$releasever/\$basearch/stable'
+        case node['platform']
+        when 'redhat'
+          baseurl 'https://repos.influxdata.com/rhel/\$releasever/\$basearch/stable'
+        when 'amazon'
+          baseurl 'https://repos.influxdata.com/centos/7/\$basearch/stable'
+        else
+          baseurl 'https://repos.influxdata.com/centos/\$releasever/\$basearch/stable'
+        end
         gpgkey 'https://repos.influxdata.com/influxdb.key'
         only_if { include_repository }
       end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -21,7 +21,8 @@ require 'spec_helper'
 describe 'telegraf::default' do
   platforms = {
     'centos' => ['6.6', '7.0'],
-    'ubuntu' => ['14.04']
+    'ubuntu' => ['14.04', '15.04'],
+    'amazon' => ['2015.09']
   }
 
   platforms.each do |platform, versions|


### PR DESCRIPTION
This addresses #15 by fixing telegraf installation on Amazon Linux.

Will also use RHEL yum repo (instead of CentOS) if the server is running RHEL.
