### PR TITLE
Fix the incorrect config of the telegraf, if the version of 'toml-rb' gem is newer than 0.3.12

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,13 +32,13 @@ default['telegraf']['config'] = {
 
 default['telegraf']['include_repository'] = true
 
-default['telegraf']['outputs'] = [
-  'influxdb' => {
+default['telegraf']['outputs'] = {
+  'influxdb' => [{
     'urls' => ['http://localhost:8086'],
     'database' => 'telegraf',
     'precision' => 's'
-  }
-]
+  }]
+}
 default['telegraf']['inputs'] = {
   'cpu' => {
     'percpu' => true,

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -19,7 +19,7 @@
 
 property :name, String, name_property: true
 property :config, Hash, default: {}
-property :outputs, Array, default: []
+property :outputs, Hash, default: {}
 property :inputs, Hash, default: {}
 property :path, String, default: node['telegraf']['config_file_path']
 

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 property :name, String, name_property: true
-property :outputs, Array, required: true
+property :outputs, Hash, required: true
 property :path, String,
          default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'


### PR DESCRIPTION
Telegraf doesn't start if toml-rb gem newer than 0.3.12. The current behavior of the resource telegraf_ouputs is incorrect. If we pass array into `outputs` attribute, it will be serialize into array of hashes. But telegraf expects that this will be a hash, where values are arrays. This behavior works with `toml-rb` gem before version 0.3.13, where bug was fix with incorrect dump of a nested tables.

This PR carries breaking changes.
