### PR TITLE
Pin toml-rb version to 0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,6 @@
 # 0.3.4
 - PR#16 - fix installation on Amazon Linux; add tests for ubuntu 15.04 and amazon linux
 - PR#19 - enforce permissions on config files, optionally suppress logging file updates
+
+# 0.3.5
+- Pin toml-rb to v0.3.12

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'apache2'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.3.4'
+version '0.3.5'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 
 depends 'yum'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -27,7 +27,9 @@ default_action :create
 
 action :create do
   chef_gem 'toml-rb' do
+    version '0.3.12'
     compile_time true if respond_to?(:compile_time)
+    action [:install, :upgrade]
   end
 
   require 'toml'

--- a/resources/inputs.rb
+++ b/resources/inputs.rb
@@ -34,7 +34,9 @@ action :create do
   end
 
   chef_gem 'toml-rb' do
+    version '0.3.12'
     compile_time true if respond_to?(:compile_time)
+    action [:install, :upgrade]
   end
 
   require 'toml'

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -34,7 +34,9 @@ action :create do
   end
 
   chef_gem 'toml-rb' do
+    version '0.3.12'
     compile_time true if respond_to?(:compile_time)
+    action [:install, :upgrade]
   end
 
   require 'toml'


### PR DESCRIPTION
toml-rb newer than 0.3.12 breaks the telegraf config
