### PR TITLE
Pin toml-rb to v0.3.x and bump telegraf to 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,7 @@
 
 # 0.3.5
 - Pin toml-rb to v0.3.12
+
+# 0.4.0 [unreleased]
+- Pin toml-rb to '~> 0.3.0'
+- Upgrade to telegraf 0.11.1

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 # version of telegraf to install, e.g. '0.10.0-1' or nil for the latest
-default['telegraf']['version'] = '0.10.3-1'
+default['telegraf']['version'] = '0.11.1-1'
 default['telegraf']['config_file_path'] = '/etc/telegraf/telegraf.conf'
 default['telegraf']['config'] = {
   'tags' => {},

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'apache2'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.3.5'
+version '0.4.0'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 
 depends 'yum'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -27,9 +27,8 @@ default_action :create
 
 action :create do
   chef_gem 'toml-rb' do
-    version '0.3.12'
+    version '~> 0.3.0'
     compile_time true if respond_to?(:compile_time)
-    action [:install, :upgrade]
   end
 
   require 'toml'

--- a/resources/inputs.rb
+++ b/resources/inputs.rb
@@ -34,9 +34,8 @@ action :create do
   end
 
   chef_gem 'toml-rb' do
-    version '0.3.12'
+    version '~> 0.3.0'
     compile_time true if respond_to?(:compile_time)
-    action [:install, :upgrade]
   end
 
   require 'toml'

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -34,9 +34,8 @@ action :create do
   end
 
   chef_gem 'toml-rb' do
-    version '0.3.12'
+    version '~> 0.3.0'
     compile_time true if respond_to?(:compile_time)
-    action [:install, :upgrade]
   end
 
   require 'toml'


### PR DESCRIPTION
This pins toml-rb to 0.3.x and bumps the default telegraf version to 0.11.x.  This won't be released until https://github.com/NorthPage/telegraf-cookbook/pull/21 also gets merged.
