### PR TITLE
add compatibility chef version < 12.5

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 # version of telegraf to install, e.g. '0.10.0-1' or nil for the latest
-default['telegraf']['version'] = '0.11.1-1'
+default['telegraf']['version'] = nil
 default['telegraf']['config_file_path'] = '/etc/telegraf/telegraf.conf'
 default['telegraf']['config'] = {
   'tags' => {},

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,4 @@ source_url 'https://github.com/NorthPage/telegraf-cookbook'
 
 depends 'yum'
 depends 'apt'
+depends 'compat_resource'


### PR DESCRIPTION
Please add compatibility with all chef 12.X
Also change default telegraph version to `nil` for install latest version from repository by default
