### PR TITLE
Default to latest telegraf; only use stable apt repo

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 # version of telegraf to install, e.g. '0.10.0-1' or nil for the latest
-default['telegraf']['version'] = '0.11.1-1'
+default['telegraf']['version'] = nil
 default['telegraf']['config_file_path'] = '/etc/telegraf/telegraf.conf'
 default['telegraf']['config'] = {
   'tags' => {},

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -49,7 +49,7 @@ action :create do
       apt_repository 'influxdb' do
         uri "https://repos.influxdata.com/#{node['platform']}"
         distribution node['lsb']['codename']
-        components ['stable', 'unstable']
+        components ['stable']
         arch 'amd64'
         key 'https://repos.influxdata.com/influxdb.key'
         only_if { include_repository }


### PR DESCRIPTION
To fix #26 
Also default to latest telegraf version as it keeps changing and will break the cookbook especially for Ubuntu which only has the latest version in apt stable.
