### PR TITLE
Add retry for telegraf service restart

### DIFF
--- a/resources/inputs.rb
+++ b/resources/inputs.rb
@@ -42,6 +42,8 @@ action :create do
 
   service "telegraf_#{new_resource.service_name}" do
     service_name 'telegraf'
+    retries 2
+    retry_delay 5
     action :nothing
   end
 


### PR DESCRIPTION
We are seeing often converge fails when telegraf is running on systemd init system, like in CentOS 7. It fails at first converge when new 'inputs' resource is added. Error can be reproduces on OpenVZ with centos-7-x86_64 template.

```
    Mixlib::ShellOut::ShellCommandFailed
           ------------------------------------
           service[telegraf_default] (/tmp/kitchen/cache/cookbooks/telegraf/resources/inputs.rb line 44) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
           ---- Begin output of /bin/systemctl --system restart telegraf ----
           STDOUT: 
           STDERR: Job for telegraf.service failed because start of the service was attempted too often. See "systemctl status telegraf.service" and "journalctl -xe" for details.
           To force a start use "systemctl reset-failed telegraf.service" followed by "systemctl start telegraf.service" again.
           ---- End output of /bin/systemctl --system restart telegraf ----
           Ran /bin/systemctl --system restart telegraf returned 1
```

Second converge terminates OK and ps show me that telegraf is running.

This PR fix this problem by added retries to service restart.
