### PR TITLE
Fixes broken apt-get install for version 1.0.x

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'apache2'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.4.0'
+version '0.4.1'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 
 depends 'yum'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -57,6 +57,7 @@ action :create do
     end
 
     package 'telegraf' do
+      options '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
       version install_version
     end
   when 'tarball'


### PR DESCRIPTION
Before this fix the package resource that is used to install telegraf would hang waiting for interactive input. This fix basically tells apt "don't overwrite my configuration". Tested and it works.

http://www.microhowto.info/howto/perform_an_unattended_installation_of_a_debian_package.html

This is the error we encountered and fixed.

```
[2016-09-15T20:43:39+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2016-09-15T20:43:39+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2016-09-15T20:43:39+00:00] ERROR: telegraf_install[default] (telegraf::default line 19) had an error: Mixlib::ShellOut::ShellCommandFailed: apt_package[telegraf] (/var/chef/cache/cookbooks/telegraf/resources/install.rb line 59) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '100'
---- Begin output of apt-get -q -y install telegraf=1.0.* ----
STDOUT: Reading package lists...
Building dependency tree...
Reading state information...
telegraf is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 24 not upgraded.
1 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Setting up telegraf (1.0.0-1) ...
STDERR: Configuration file '/etc/telegraf/telegraf.conf'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** telegraf.conf (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package telegraf (--configure):
 EOF on stdin at conffile prompt
Errors were encountered while processing:
 telegraf
E: Sub-process /usr/bin/dpkg returned an error code (1)
---- End output of apt-get -q -y install telegraf=1.0.* ----
Ran apt-get -q -y install telegraf=1.0.* returned 100
[2016-09-15T20:43:39+00:00] ERROR: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```
