### PR TITLE
Rename the sensitive resource to rootonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,6 @@
 
 # 0.4.1
 - PR#34 - Allow specifying gem source for toml-rb
+
+## Unreleased
+- Rename sensitive resource to rootonly as it will raise an exception in Chef13

--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ telegraf_inputs 'nginx' do
   inputs node['telegraf']['nginx']
   service_name 'default'
   reload true
-  sensitive false
+  rootonly false
 end
 ```
 
 Note that there are three optional parameters for this resource that could've been left out in this case:
   - service_name [default: 'default'] if you need to override which service should be restarted when the config changes;
   - reload [default: true] whether to restart the service when the config changes;
-  - sensitive [default: false] whether to restrict access to the config file so it's not world readable;
+  - rootonly [default: false] whether to restrict access to the config file so it's not world readable;
 
 ## License and Authors
 

--- a/resources/inputs.rb
+++ b/resources/inputs.rb
@@ -23,7 +23,7 @@ property :path, String,
          default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'
 property :reload, kind_of: [TrueClass, FalseClass], default: true
-property :sensitive, kind_of: [TrueClass, FalseClass], default: false
+property :rootonly, kind_of: [TrueClass, FalseClass], default: false
 
 default_action :create
 
@@ -53,8 +53,8 @@ action :create do
     content TOML.dump('inputs' => inputs)
     user 'root'
     group 'telegraf'
-    mode new_resource.sensitive ? '0640' : '0644'
-    sensitive new_resource.sensitive
+    mode new_resource.rootonly ? '0640' : '0644'
+    sensitive new_resource.rootonly
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
   end
 end

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -23,7 +23,7 @@ property :path, String,
          default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'
 property :reload, kind_of: [TrueClass, FalseClass], default: true
-property :sensitive, kind_of: [TrueClass, FalseClass], default: false
+property :rootonly, kind_of: [TrueClass, FalseClass], default: false
 
 default_action :create
 
@@ -53,8 +53,8 @@ action :create do
     content TOML.dump('outputs' => outputs)
     user 'root'
     group 'telegraf'
-    mode new_resource.sensitive ? '0640' : '0644'
-    sensitive new_resource.sensitive
+    mode new_resource.rootonly ? '0640' : '0644'
+    sensitive new_resource.rootonly
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
   end
 end


### PR DESCRIPTION
Seems like we use the sensitive resource and also create a resource called sensitive... this breaks in Chef13.

I renamed it to rootonly as it's not just muting the output to chef but it's making it only read-able by root.

