### PR TITLE
Adding delete action to input/output LWRPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,4 @@
 
 ## Unreleased
 - Rename sensitive resource to rootonly as it will raise an exception in Chef13
+- PR#37 - Add delete action to input/output LWRPs

--- a/resources/inputs.rb
+++ b/resources/inputs.rb
@@ -58,3 +58,10 @@ action :create do
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
   end
 end
+
+action :delete do
+  file "#{path}/#{name}_inputs.conf" do
+    action :delete
+    notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
+  end
+end

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -58,3 +58,10 @@ action :create do
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
   end
 end
+
+action :delete do
+  file "#{path}/#{name}_outputs.conf" do
+    action :delete
+    notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
+  end
+end


### PR DESCRIPTION
It'd be useful to have a delete action on the input and output LWRPs when cleaning up an old one.