### PR TITLE
support install_type=file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,8 +19,22 @@
 
 # version of telegraf to install, e.g. '0.10.0-1' or nil for the latest
 default['telegraf']['version'] = nil
+default['telegraf']['install_type'] = 'package'
 default['telegraf']['rubysource'] = 'https://rubygems.org'
+
+default['telegraf']['download_urls'] = {
+  'debian' => 'https://dl.influxdata.com/telegraf/releases',
+  'rhel' => 'https://dl.influxdata.com/telegraf/releases'
+}
+
+# platform_family keyed download sha256 checksums
+default['telegraf']['shasums'] = {
+  'debian' => '',
+  'rhel' => ''
+}
+
 default['telegraf']['config_file_path'] = '/etc/telegraf/telegraf.conf'
+
 default['telegraf']['config'] = {
   'tags' => {},
   'agent' => {

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 telegraf_install 'default' do
   include_repository node['telegraf']['include_repository']
   install_version node['telegraf']['version']
+  install_type node['telegraf']['install_type']
   action :create
 end
 


### PR DESCRIPTION
adds support for getting the package file using `remote_file`. Must be used with more recent versions of telegraf since the debian repository seems stale.