### PR TITLE
More tests for the inputs file

### DIFF
--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -13,13 +13,29 @@ end
   end
 end
 
-%w( telegraf.conf telegraf.d/default_outputs.conf telegraf.d/default_inputs.conf ).each do |c|
+%w( telegraf.conf telegraf.d/default_outputs.conf ).each do |c|
   describe file("#{conf_dir}/#{c}") do
     it { should be_file }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'telegraf' }
     it { should be_mode '644' }
   end
+end
+
+describe file("#{conf_dir}/telegraf.d/default_inputs.conf") do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'telegraf' }
+  it { should be_mode '644' }
+  it { should contain 'inputs.cpu' }
+  it { should contain 'percpu = true' }
+  it { should contain 'totalcpu = true' }
+  it { should contain 'inputs.disk' }
+  it { should contain 'inputs.io' }
+  it { should contain 'inputs.mem' }
+  it { should contain 'inputs.net' }
+  it { should contain 'inputs.swap' }
+  it { should contain 'inputs.system' }
 end
 
 describe service('telegraf') do


### PR DESCRIPTION
The latest update does not generate the default_inputs.conf file properly. I have added tests to make sure the file includes the settings form the default attributes file.