### PR TITLE
fixing default inputs to include default system metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cookbook.  ie. `[netstat]` requires `lsof`
 
 * CentOS 6.8 and 7.3
 * Ubuntu 15.04 and 16.04
-* Amazon Linux 
+* Amazon Linux
 
 ## Requirements
 
@@ -31,7 +31,7 @@ as needed.  Alternatively, you can use the custom resources directly.
 | node['telegraf']['config']           | Hash   | Config variables to be written to the telegraf config | {'tags' => {},'agent' => {'interval' => '10s','round_interval' => true,'flush_interval' => '10s','flush_jitter' => '5s'}                                            |
 | node['telegraf']['outputs']          | Array  | telegraf outputs                                      | ['influxdb' => {'urls' => ['http://localhost:8086'],'database' => 'telegraf','precision' => 's'}]                                                                   |
 | node['telegraf']['include_repository'] | [TrueClass, FalseClass] | Whether or not to pull in the InfluxDB repository to install from. | true |
-| node['telegraf']['inputs']           | Hash   | telegraf inputs                                       | {'cpu' => {'percpu' => true,'totalcpu' => true,'drop' => ['cpu_time'],},'disk' => {},'io' => {},'mem' => {},'net' => {},'swap' => {},'system' => {}}                |
+| node['telegraf']['inputs']           | Hash   | telegraf inputs                                       | {'cpu' => {'percpu' => true,'totalcpu' => true,'drop' => ['cpu_time'],},'disk' => [{}],'io' => [{}],'mem' => [{}],'net' => [{}],'swap' => [{}],'system' => [{}]}                |
 
 ### Custom Resources
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,10 +60,10 @@ default['telegraf']['inputs'] = {
     'totalcpu' => true,
     'drop' => ['cpu_time']
   },
-  'disk' => {},
-  'io' => {},
-  'mem' => {},
-  'net' => {},
-  'swap' => {},
-  'system' => {}
+  'disk' => [{}],
+  'io' => [{}],
+  'mem' => [{}],
+  'net' => [{}],
+  'swap' => [{}],
+  'system' => [{}]
 }

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -13,13 +13,29 @@ end
   end
 end
 
-%w( telegraf.conf telegraf.d/default_outputs.conf telegraf.d/default_inputs.conf ).each do |c|
+%w( telegraf.conf telegraf.d/default_outputs.conf ).each do |c|
   describe file("#{conf_dir}/#{c}") do
     it { should be_file }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'telegraf' }
     it { should be_mode '644' }
   end
+end
+
+describe file("#{conf_dir}/telegraf.d/default_inputs.conf") do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'telegraf' }
+  it { should be_mode '644' }
+  it { should contain 'inputs.cpu' }
+  it { should contain 'percpu = true' }
+  it { should contain 'totalcpu = true' }
+  it { should contain 'inputs.disk' }
+  it { should contain 'inputs.io' }
+  it { should contain 'inputs.mem' }
+  it { should contain 'inputs.net' }
+  it { should contain 'inputs.swap' }
+  it { should contain 'inputs.system' }
 end
 
 describe service('telegraf') do


### PR DESCRIPTION
Fixing broken default inputs introduced by #43 and brought up by @joshmyers and @phromo. 

I also pulled in the tests introduced in #44 by @petre so that I could ensure these changes fully worked. I can remove these if you would prefer to merge them as two PRs. 