### PR TITLE
Fixing :delete action for resource 'telegraf_outputs'

### DIFF
--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -62,6 +62,13 @@ action :create do
 end
 
 action :delete do
+  service "telegraf_#{new_resource.service_name}" do
+    service_name 'telegraf'
+    retries 2
+    retry_delay 5
+    action :nothing
+  end
+
   file "#{path}/#{name}_outputs.conf" do
     action :delete
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload


### PR DESCRIPTION
I ran into `Chef::Exceptions::ResourceNotFound` exceptions when trying to use the `:delete` action of the `telegraf_outputs` resource.

```
Chef::Exceptions::ResourceNotFound
----------------------------------
resource file[/etc/telegraf/telegraf.d/discard_outputs.conf] is configured to notify resource service[telegraf_default] with action restart, but service[telegraf_default] cannot be found in the resource collection. file[/etc/telegraf/telegraf.d/discard_outputs.conf] is defined in /var/chef/cache/cookbooks/telegraf/resources/outputs.rb:65:in `block in class_from_file'
```