### PR TITLE
Foodcritic fixes for the license property and custom resource 'name' properties

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name 'telegraf'
 maintainer 'E Camden Fisher'
 maintainer_email 'camden@northpage.com'
-license 'apache2'
+license 'Apache-2.0'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
 version '0.8.1'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-property :name, String, name_property: true
+property :config_name, String, name_property: true
 property :config, Hash, default: {}
 property :outputs, Hash, default: {}
 property :inputs, Hash, default: {}
@@ -36,7 +36,7 @@ action :create do
 
   require 'toml-rb'
 
-  service "telegraf_#{new_resource.name}" do
+  service "telegraf_#{new_resource.config_name}" do
     service_name 'telegraf'
     retries 2
     retry_delay 5
@@ -45,41 +45,41 @@ action :create do
 
   file path do
     content TomlRB.dump(new_resource.config)
-    unless node.platform_family? 'windows'
+    unless platform_family? 'windows'
       user 'root'
       group 'telegraf'
       mode '0644'
     end
-    notifies :restart, "service[telegraf_#{new_resource.name}]", :delayed
+    notifies :restart, "service[telegraf_#{new_resource.config_name}]", :delayed
   end
 
   telegraf_d = ::File.dirname(new_resource.path) + '/telegraf.d'
 
-  telegraf_outputs name do
+  telegraf_outputs config_name do
     path telegraf_d
     outputs new_resource.outputs
     reload false
     action :create
     not_if { new_resource.outputs.empty? }
-    notifies :restart, "service[telegraf_#{new_resource.name}]", :delayed
+    notifies :restart, "service[telegraf_#{new_resource.config_name}]", :delayed
   end
 
-  telegraf_inputs name do
+  telegraf_inputs config_name do
     path telegraf_d
     inputs new_resource.inputs
     reload false
     action :create
     not_if { new_resource.inputs.empty? }
-    notifies :restart, "service[telegraf_#{new_resource.name}]", :delayed
+    notifies :restart, "service[telegraf_#{new_resource.config_name}]", :delayed
   end
 
-  telegraf_perf_counters name do
+  telegraf_perf_counters config_name do
     path telegraf_d
     perf_counters new_resource.perf_counters
     reload false
     action :create
     not_if { new_resource.perf_counters.empty? }
     only_if { platform_family?('windows') }
-    notifies :restart, "service[telegraf_#{new_resource.name}]", :delayed
+    notifies :restart, "service[telegraf_#{new_resource.config_name}]", :delayed
   end
 end

--- a/resources/inputs.rb
+++ b/resources/inputs.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-property :name, String, name_property: true
+property :input_name, String, name_property: true
 property :inputs, Hash, required: true
 property :path, String,
          default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
@@ -49,9 +49,9 @@ action :create do
     action :nothing
   end
 
-  file "#{new_resource.path}/#{new_resource.name}_inputs.conf" do
+  file "#{new_resource.path}/#{new_resource.input_name}_inputs.conf" do
     content TomlRB.dump('inputs' => new_resource.inputs)
-    unless node.platform_family? 'windows'
+    unless platform_family? 'windows'
       user 'root'
       group 'telegraf'
       mode new_resource.rootonly ? '0640' : '0644'
@@ -62,7 +62,7 @@ action :create do
 end
 
 action :delete do
-  file "#{new_resource.path}/#{new_resource.name}_inputs.conf" do
+  file "#{new_resource.path}/#{new_resource.input_name}_inputs.conf" do
     action :delete
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
   end

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-property :name, String, name_property: true
+property :output_name, String, name_property: true
 property :outputs, Hash, required: true
 property :path, String,
          default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
@@ -49,9 +49,9 @@ action :create do
     action :nothing
   end
 
-  file "#{path}/#{name}_outputs.conf" do
+  file "#{path}/#{new_resource.output_name}_outputs.conf" do
     content TomlRB.dump('outputs' => outputs)
-    unless node.platform_family? 'windows'
+    unless platform_family? 'windows'
       user 'root'
       group 'telegraf'
       mode new_resource.rootonly ? '0640' : '0644'
@@ -69,7 +69,7 @@ action :delete do
     action :nothing
   end
 
-  file "#{path}/#{name}_outputs.conf" do
+  file "#{path}/#{new_resource.output_name}_outputs.conf" do
     action :delete
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
   end

--- a/resources/perf_counters.rb
+++ b/resources/perf_counters.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-property :name, String, name_property: true
+property :perf_counters_name, String, name_property: true
 property :perf_counters, Hash, required: true
 property :path, String,
          default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
@@ -77,14 +77,14 @@ action :create do
   win_perf_counters = { win_perf_counters: [] }
   win_perf_counters[:win_perf_counters] << perf_counters_objects
 
-  file "#{path}/#{name}_perf_counters.conf" do
+  file "#{path}/#{new_resource.perf_counters_name}_perf_counters.conf" do
     content TomlRB.dump('inputs' => win_perf_counters)
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
   end
 end
 
 action :delete do
-  file "#{path}/#{name}_perf_counters.conf" do
+  file "#{path}/#{new_resource.perf_counters_name}_perf_counters.conf" do
     action :delete
     notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
   end


### PR DESCRIPTION
Fixes some foodcritic complaints for:
* FC069: Ensure standardized license defined in metadata.  (This is **not** a license change)
* FC108: Resource should not define a property named 'name'.

I also consistently used `new_resource.xxxxx`