### PR TITLE
Fix Chef-13 warning for namespace collision deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.2
+- PR#xx - Fix Chef-13 warning for https://docs.chef.io/deprecations_namespace_collisions.html
+- Cleanup all foodcritic warnings
+
 ## 0.9.1
 
 - PR#65 - Chef-13 amazon compatibility fix

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name 'telegraf'
 maintainer 'E Camden Fisher'
 maintainer_email 'camden@northpage.com'
-license 'apache2'
+license 'Apache-2.0'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.9.1'
+version '0.9.2'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 issues_url 'https://github.com/NorthPage/telegraf-cookbook/issues'
 

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -17,7 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-property :name, String, name_property: true
 property :config, Hash, default: {}
 property :outputs, Hash, default: {}
 property :inputs, Hash, default: {}
@@ -43,9 +42,9 @@ action :create do
     action :nothing
   end
 
-  file path do
+  file new_resource.path do
     content TomlRB.dump(new_resource.config)
-    unless node.platform_family? 'windows'
+    unless platform_family? 'windows'
       user 'root'
       group 'telegraf'
       mode '0644'
@@ -55,7 +54,7 @@ action :create do
 
   telegraf_d = ::File.dirname(new_resource.path) + '/telegraf.d'
 
-  telegraf_outputs name do
+  telegraf_outputs new_resource.name do
     path telegraf_d
     outputs new_resource.outputs
     reload false
@@ -64,7 +63,7 @@ action :create do
     notifies :restart, "service[telegraf_#{new_resource.name}]", :delayed
   end
 
-  telegraf_inputs name do
+  telegraf_inputs new_resource.name do
     path telegraf_d
     inputs new_resource.inputs
     reload false
@@ -73,7 +72,7 @@ action :create do
     notifies :restart, "service[telegraf_#{new_resource.name}]", :delayed
   end
 
-  telegraf_perf_counters name do
+  telegraf_perf_counters new_resource.name do
     path telegraf_d
     perf_counters new_resource.perf_counters
     reload false

--- a/resources/inputs.rb
+++ b/resources/inputs.rb
@@ -17,10 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-property :name, String, name_property: true
 property :inputs, Hash, required: true
-property :path, String,
-         default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
+property :path, String, default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'
 property :reload, kind_of: [TrueClass, FalseClass], default: true
 property :rootonly, kind_of: [TrueClass, FalseClass], default: false
@@ -28,7 +26,7 @@ property :rootonly, kind_of: [TrueClass, FalseClass], default: false
 default_action :create
 
 action :create do
-  directory path do
+  directory new_resource.path do
     recursive true
     action :create
   end
@@ -51,19 +49,19 @@ action :create do
 
   file "#{new_resource.path}/#{new_resource.name}_inputs.conf" do
     content TomlRB.dump('inputs' => new_resource.inputs)
-    unless node.platform_family? 'windows'
+    unless platform_family? 'windows'
       user 'root'
       group 'telegraf'
       mode new_resource.rootonly ? '0640' : '0644'
     end
     sensitive new_resource.rootonly
-    notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
+    notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if new_resource.reload
   end
 end
 
 action :delete do
   file "#{new_resource.path}/#{new_resource.name}_inputs.conf" do
     action :delete
-    notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
+    notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if new_resource.reload
   end
 end

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -17,10 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-property :name, String, name_property: true
 property :outputs, Hash, required: true
-property :path, String,
-         default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
+property :path, String, default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'
 property :reload, kind_of: [TrueClass, FalseClass], default: true
 property :rootonly, kind_of: [TrueClass, FalseClass], default: false
@@ -28,7 +26,7 @@ property :rootonly, kind_of: [TrueClass, FalseClass], default: false
 default_action :create
 
 action :create do
-  directory path do
+  directory new_resource.path do
     recursive true
     action :create
   end
@@ -49,15 +47,15 @@ action :create do
     action :nothing
   end
 
-  file "#{path}/#{name}_outputs.conf" do
-    content TomlRB.dump('outputs' => outputs)
-    unless node.platform_family? 'windows'
+  file "#{new_resource.path}/#{new_resource.name}_outputs.conf" do
+    content TomlRB.dump('outputs' => new_resource.outputs)
+    unless platform_family? 'windows'
       user 'root'
       group 'telegraf'
       mode new_resource.rootonly ? '0640' : '0644'
     end
     sensitive new_resource.rootonly
-    notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
+    notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if new_resource.reload
   end
 end
 
@@ -69,8 +67,8 @@ action :delete do
     action :nothing
   end
 
-  file "#{path}/#{name}_outputs.conf" do
+  file "#{new_resource.path}/#{new_resource.name}_outputs.conf" do
     action :delete
-    notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if reload
+    notifies :restart, "service[telegraf_#{new_resource.service_name}]", :delayed if new_resource.reload
   end
 end


### PR DESCRIPTION
- NOTE: This change does not break backwards compatibility https://docs.chef.io/deprecations_namespace_collisions.html
- Cleanup all foodcritic warnings