### PR TITLE
Add support for non `amd64` architectures

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -45,11 +45,25 @@ action :create do
         only_if { new_resource.include_repository }
       end
 
+      case node['kernel']['machine']
+      when 'x86_64'
+        telegraf_arch = 'amd64'
+      when 'i686', 'i386'
+        telegraf_arch = 'i386'
+      when 'armv7l', 'armv6l'
+        telegraf_arch = 'armhf'
+      when 'armv5l'
+        telegraf_arch = 'armel'
+      else
+        telegraf_arch = 'amd64'
+        Chef::Log.warn('Arch not detected properly, falling back to amd64')
+      end
+
       apt_repository 'influxdb' do
         uri "#{node['telegraf']['package_url']}/#{node['platform']}"
         distribution node['lsb']['codename']
         components ['stable']
-        arch 'amd64'
+        arch telegraf_arch
         key "#{node['telegraf']['package_url']}/influxdb.key"
         only_if { new_resource.include_repository }
       end


### PR DESCRIPTION
Currently the arch is hardcoded to `amd64` - this adds the support to detect and use the appropriate architecture for the influx repos based on the machine. 

Thank you @mignaulo for tracking and discovering the hardcoded variable!