### PR TITLE
Execute CI tests/linter fixes

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,76 @@
+---
+driver:
+  name: dokken
+  chef_version: latest
+  privileged: true
+  volumes: [
+    '/var/lib/docker', '/var/lib/docker-one', '/var/lib/docker-two'
+  ]
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  deprecations_as_errors: true
+
+verifier:
+  name: inspec
+
+platforms:
+- name: debian-9
+  driver:
+    image: dokken/debian-9
+    pid_one_command: /bin/systemd
+
+- name: centos-6
+  driver:
+    image: dokken/centos-6
+    pid_one_command: /sbin/init
+
+- name: centos-7
+  driver:
+    image: dokken/centos-7
+    pid_one_command: /usr/lib/systemd/systemd
+
+- name: ubuntu-14.04
+  driver:
+    image: dokken/ubuntu-14.04
+    pid_one_command: /sbin/init
+
+- name: ubuntu-16.04
+  driver:
+    image: dokken/ubuntu-16.04
+    pid_one_command: /bin/systemd
+
+- name: amazonlinux
+  driver:
+    image: dokken/amazonlinux
+    pid_one_command: /sbin/init
+
+suites:
+  - name: default
+    run_list:
+      - recipe[telegraf::default]
+    attributes:
+      telegraf:
+        outputs:
+          influxdb:
+            urls: ['http://localhost:8086']
+            database: 'telegraf'
+            precision: 's'
+  - name: file
+    run_list:
+      - recipe[telegraf::default]
+    attributes:
+      telegraf:
+        install_type: file
+        version: 1.4.1-1
+        shasums: 
+          debian: f70ca532511a92e590eaf129ee816dd7cd8c0f7eeb62b41e1b8c8623334d6a8d
+          rhel: 76ae1248890b399c5964d254fc763587b60059ab45081e73d7cad805fa97615b
+        outputs:
+          influxdb:
+            urls: ['http://localhost:8086']
+            database: 'telegraf'
+            precision: 's'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 LineLength:
-  Max: 100
+  Max: 110
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+sudo: required
+dist: trusty
+
+addons:
+  apt:
+    sources:
+      - chef-current-trusty
+    packages:
+      - chefdk
+
+# Don't `bundle install` which takes about 1.5 mins
+install: echo "skip bundle install"
+
+# disable while testing travis
+# branches:
+#   only:
+#     - master
+
+services: docker
+
+env:
+  matrix:
+  - INSTANCE=installation-script-main-ubuntu-1604
+  - INSTANCE=installation-tarball-ubuntu-1604
+  - INSTANCE=installation-package-ubuntu-1604
+  - INSTANCE=registry-ubuntu-1604
+  - INSTANCE=network-ubuntu-1604
+  - INSTANCE=volume-ubuntu-1604
+  - INSTANCE=resources-debian-8
+  - INSTANCE=resources-debian-9
+  - INSTANCE=resources-centos-7
+  - INSTANCE=resources-fedora-27
+  - INSTANCE=resources-ubuntu-1404
+  - INSTANCE=resources-ubuntu-1604
+
+# Ensure we make ChefDK's Ruby the default
+before_script:
+  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+  - eval "$(chef shell-init bash)"
+  - chef --version
+  - cookstyle --version
+  - foodcritic --version
+
+script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
+
+matrix:
+  include:
+    - script:
+      - chef exec delivery local all
+      env: UNIT_AND_LINT=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,18 @@ services: docker
 
 env:
   matrix:
-  - INSTANCE=installation-script-main-ubuntu-1604
-  - INSTANCE=installation-tarball-ubuntu-1604
-  - INSTANCE=installation-package-ubuntu-1604
-  - INSTANCE=registry-ubuntu-1604
-  - INSTANCE=network-ubuntu-1604
-  - INSTANCE=volume-ubuntu-1604
-  - INSTANCE=resources-debian-8
-  - INSTANCE=resources-debian-9
-  - INSTANCE=resources-centos-7
-  - INSTANCE=resources-fedora-27
-  - INSTANCE=resources-ubuntu-1404
-  - INSTANCE=resources-ubuntu-1604
+  - INSTANCE=default-amazonlinux
+  - INSTANCE=default-centos-6
+  - INSTANCE=default-centos-7
+  - INSTANCE=default-debian-9
+  - INSTANCE=default-ubuntu-1604
+  - INSTANCE=default-ubuntu-1404
+  - INSTANCE=file-amazonlinux
+  - INSTANCE=file-centos-6
+  - INSTANCE=file-centos-7
+  - INSTANCE=file-debian-9
+  - INSTANCE=file-ubuntu-1604
+  - INSTANCE=file-ubuntu-1404
 
 # Ensure we make ChefDK's Ruby the default
 before_script:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # telegraf
 
+[![Build Status](https://travis-ci.org/NorthPage/telegraf-cookbook.svg?branch=master)](https://travis-ci.org/NorthPage/telegraf-cookbook)
+
 Cookbook to install and configure [telegraf](https://github.com/influxdb/telegraf)
 
 This was influenced by [SimpleFinanace/chef-influxdb](https://github.com/SimpleFinance/chef-influxdb)

--- a/resources/inputs.rb
+++ b/resources/inputs.rb
@@ -20,8 +20,8 @@
 property :inputs, Hash, required: true
 property :path, String, default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'
-property :reload, kind_of: [TrueClass, FalseClass], default: true
-property :rootonly, kind_of: [TrueClass, FalseClass], default: false
+property :reload, [true, false], default: true
+property :rootonly, [true, false], default: false
 
 default_action :create
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -71,7 +71,7 @@ action :create do
       include_recipe 'chocolatey'
     elsif platform_family? 'mac_os_x'
       include_recipe 'homebrew'
-      
+
       group 'telegraf' do
         action :create
       end
@@ -156,9 +156,7 @@ action :create do
 
       windows_package 'telegraf' do
         source "#{ENV['ProgramW6432']}\\telegraf\\telegraf.exe"
-        # rubocop:disable Metrics/LineLength
         options "--service install --config-directory \"#{ENV['ProgramW6432']}\\telegraf\\telegraf.d\""
-        # rubocop:enable Metrics/LineLength
         installer_type :custom
         action :install
         only_if { !::Win32::Service.exists?('telegraf') }

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -20,8 +20,8 @@
 property :outputs, Hash, required: true
 property :path, String, default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'
-property :reload, kind_of: [TrueClass, FalseClass], default: true
-property :rootonly, kind_of: [TrueClass, FalseClass], default: false
+property :reload, [true, false], default: true
+property :rootonly, [true, false], default: false
 
 default_action :create
 

--- a/resources/perf_counters.rb
+++ b/resources/perf_counters.rb
@@ -20,7 +20,7 @@
 property :perf_counters, Hash, required: true
 property :path, String, default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
 property :service_name, String, default: 'default'
-property :reload, kind_of: [TrueClass, FalseClass], default: true
+property :reload, [true, false], default: true
 
 default_action :create
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -20,10 +20,11 @@ require 'spec_helper'
 
 describe 'telegraf::default' do
   platforms = {
-    'centos' => ['6.6', '7.0'],
-    'ubuntu' => ['14.04', '15.04'],
-    'amazon' => ['2015.09'],
-    'windows' => ['2012r2'],
+    'amazon' => ['2015.09', '2016.03', '2016.09', '2017.03', '2017.09'],
+    'centos' => ['6.8', '6.9', '7.3.1611', '7.4.1708'],
+    'mac_os_x' => ['10.12', '10.13'],
+    'ubuntu' => ['14.04', '16.04'],
+    'windows' => ['2012R2'],
   }
 
   platforms.each do |platform, versions|


### PR DESCRIPTION
Executes build on [TravisCI](https://travis-ci.org/NorthPage/telegraf-cookbook).  Fixes a few `cookstyle` linter errors.
