### PR TITLE
Don't start the service after installation

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -171,7 +171,7 @@ action :create do
 
   service "telegraf_#{new_resource.name}" do
     service_name 'telegraf'
-    action [:enable, :start]
+    action [:enable]
   end
 end
 


### PR DESCRIPTION
We ran into the issue that after changing the configuration files
the service didn't start. After correcting the issue, the service
tries to start before the configuration is corrected.