### PR TITLE
Using lazy to fix attribute handling in resources and fix cases for chocolatey package upgrade 

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,16 +17,16 @@
 # limitations under the License.
 
 telegraf_install 'default' do
-  include_repository node['telegraf']['include_repository']
-  install_version node['telegraf']['version']
-  install_type node['telegraf']['install_type']
+  include_repository lazy { node['telegraf']['include_repository'] }
+  install_version lazy { node['telegraf']['version'] }
+  install_type lazy { node['telegraf']['install_type'] }
   action :create
 end
 
 telegraf_config 'default' do
-  path node['telegraf']['config_file_path']
-  config node['telegraf']['config']
-  outputs node['telegraf']['outputs']
-  perf_counters node['telegraf']['perf_counters']
-  inputs node['telegraf']['inputs']
+  path lazy { node['telegraf']['config_file_path'] }
+  config lazy { node['telegraf']['config'] }
+  outputs lazy { node['telegraf']['outputs'] }
+  perf_counters lazy { node['telegraf']['perf_counters'] }
+  inputs lazy { node['telegraf']['inputs'] }
 end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -90,6 +90,14 @@ action :create do
     end
 
     if platform_family? 'windows'
+      if telegraf_install?
+        service "telegraf_#{new_resource.name}" do
+          service_name 'telegraf'
+          action [:stop]
+          only_if { ::Win32::Service.exists?('telegraf') }
+        end
+      end
+
       chocolatey_package 'telegraf' do
         version new_resource.install_version
         source node['telegraf']['chocolatey_source']


### PR DESCRIPTION
Using "lazy" while passing attributes to custom resources
- This will allow other app cookbooks / wrappers / role cookbooks in the run-list to be able to set telegraf input / output / perf_counter or other installation attributes even if they are later than telegraf cookbook in the run-list during compilation. This way, correct / desired values of attributes will be used.

Chocolatey package upgrade cases: If an older version is already installed
- we need to stop the service so files will not be in use
- Use action :upgrade instead of :install, which covers both actions