### PR TITLE
Respect config file path attribute on MacOS

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -78,9 +78,9 @@ action :create do
         action :create
       end
 
-      cookbook_file '/Library/LaunchDaemons/com.influxdata.telegraf.plist' do
+      template '/Library/LaunchDaemons/com.influxdata.telegraf.plist' do
         action :create
-        content 'com.influxdata.telegraf.plist'
+        source 'com.influxdata.telegraf.plist.erb'
         cookbook 'telegraf'
       end
 

--- a/templates/mac_os_x/com.influxdata.telegraf.plist.erb
+++ b/templates/mac_os_x/com.influxdata.telegraf.plist.erb
@@ -8,9 +8,9 @@
         <array>
             <string>/usr/local/bin/telegraf</string>
             <string>--config</string>
-            <string>/etc/telegraf/telegraf.conf</string>
+            <string><%= node['telegraf']['config_file_path'] %></string>
             <string>--config-directory</string>
-            <string>/etc/telegraf/telegraf.d/</string>
+            <string><%= ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d/'%></string>
         </array>
         <key>KeepAlive</key>
         <true/>


### PR DESCRIPTION
Configure LaunchDaemon with correct configuration paths as specified by node['telegraf']['config_file_path'] attribute. Homebrew installs configuration files to /usr/local/etc by default.