### PR TITLE
Fix package upgrade when install_type = 'file'

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -120,6 +120,7 @@ action :create do
 
       rpm_package 'telegraf' do
         source "#{Chef::Config[:file_cache_path]}/#{file_name}"
+        version new_resource.install_version
         action :install
       end
     elsif platform_family? 'debian'
@@ -134,6 +135,7 @@ action :create do
       dpkg_package 'telegraf' do
         source "#{Chef::Config[:file_cache_path]}/#{file_name}"
         options '--force-confdef --force-confold'
+        version new_resource.install_version
         action :install
       end
     elsif platform_family? 'windows'


### PR DESCRIPTION
Normally I want to control which telegraf version to deploy, therefore I follow  `install_type = 'file'` approach.

Problem:

  When I change `node['telegraf']['version']` - new telegraf package is downloaded but never installed.
 

This patch solves this problem for `install_type = 'file'` only.
