### PR TITLE
wrap node attribute resource defaults in lazy blocks

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -21,7 +21,7 @@ property :config, Hash, default: {}
 property :outputs, Hash, default: {}
 property :inputs, Hash, default: {}
 property :perf_counters, Hash, default: {}
-property :path, String, default: node['telegraf']['config_file_path']
+property :path, String, default: lazy { node['telegraf']['config_file_path'] }
 
 default_action :create
 

--- a/resources/inputs.rb
+++ b/resources/inputs.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 property :inputs, Hash, required: true
-property :path, String, default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
+property :path, String, default: lazy { ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d' }
 property :service_name, String, default: 'default'
 property :reload, [true, false], default: true
 property :rootonly, [true, false], default: false

--- a/resources/outputs.rb
+++ b/resources/outputs.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 property :outputs, Hash, required: true
-property :path, String, default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
+property :path, String, default: lazy { ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d' }
 property :service_name, String, default: 'default'
 property :reload, [true, false], default: true
 property :rootonly, [true, false], default: false

--- a/resources/perf_counters.rb
+++ b/resources/perf_counters.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 property :perf_counters, Hash, required: true
-property :path, String, default: ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d'
+property :path, String, default: lazy { ::File.dirname(node['telegraf']['config_file_path']) + '/telegraf.d' }
 property :service_name, String, default: 'default'
 property :reload, [true, false], default: true
 


### PR DESCRIPTION
Newer ChefSpec (7.2+ most likely) fails on recipes using custom resources from this cookbook
that have property defaults that use node attributes. The reason is unclear, but these failures
can be fixed by just wrapping the defaults in a lazy block.

I've opened an issue with ChefSpec. https://github.com/chefspec/chefspec/issues/985