### PR TITLE
Removing the v in the version

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -17,7 +17,7 @@ module Telegraf
         query = ''
       end
 
-      matches = /^Telegraf v(?<version>(\d+\.)?(\d+\.)?(\*|\d+)).*/.match(query)
+      matches = /^Telegraf (?<version>(\d+\.)?(\d+\.)?(\*|\d+)).*/.match(query)
       matches ? Gem::Version.new(matches[:version]) : Gem::Version.new('0.0.0')
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license 'Apache-2.0'
 description 'Installs/Configures telegraf'
 long_description 'Installs/Configures telegraf'
-version '0.12.0'
+version '0.12.1002'
 source_url 'https://github.com/NorthPage/telegraf-cookbook'
 issues_url 'https://github.com/NorthPage/telegraf-cookbook/issues'
 


### PR DESCRIPTION
Current version check does not match the version output
query = shell_out("#{telegraf_executable} --version").stdout.chomp
 => "Telegraf 1.14.2 (git: HEAD fb74eaf2)"

Matches = /^Telegraf v(?<version>(\d+\.)?(\d+\.)?(\*|\d+)).*/.match(query)
 => nil

matches = /^Telegraf (?<version>(\d+\.)?(\d+\.)?(\*|\d+)).*/.match(query)
 => #<MatchData "Telegraf 1.14.2 (git: HEAD fb74eaf2)" version:"1.14.2">