### PR TITLE
Add apt package support for ARM64

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -56,6 +56,8 @@ action :create do
         telegraf_arch = 'armhf'
       when 'armv5l'
         telegraf_arch = 'armel'
+      when 'aarch64'
+        telegraf_arch = 'arm64'
       else
         telegraf_arch = 'amd64'
         Chef::Log.warn('Arch not detected properly, falling back to amd64')


### PR DESCRIPTION
Thanks for this awesome cookbook!  I ran into issues using this on a Raspberry Pi 4 running the ARM64 build of Ubuntu 20.04.  The InfluxDB repo has arm64 packages that can be installed for this platform, so I went ahead and added the mapping for aarch64 => arm64 to your install recipe.  I was able to install and configure telegraf on two RPi4 systems using this patch.